### PR TITLE
Switch to Crates.io from github dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 
 [dependencies]
-askama = { git = "https://github.com/djc/askama" }
+askama = "0.7"
 criterion = "0.2"
-handlebars = { git = "https://github.com/sunng87/handlebars-rust" }
-horrorshow = { git = "https://github.com/Stebalien/horrorshow-rs" }
-liquid = { git = "https://github.com/cobalt-org/liquid-rust" }
+handlebars = "1"
+horrorshow = "0.6"
+liquid = "0.15"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.7"
-tera = { git = "https://github.com/Keats/tera" }
+tera = "0.11"
 
 [[bench]]
 name = "all"


### PR DESCRIPTION
By using crates.io and semantic versioning, it is insures that cargo will not accidentally pull in a version that is not compatible with template-benchmarks-rs. If github is used, the newest version will be pulled in, but it could potentially break this code.