### PR TITLE
Ructe support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 
 [dependencies]
-askama = { git = "https://github.com/djc/askama" }
+askama = "0.7"
 criterion = "0.2"
-handlebars = { git = "https://github.com/sunng87/handlebars-rust" }
-horrorshow = { git = "https://github.com/Stebalien/horrorshow-rs" }
-liquid = { git = "https://github.com/cobalt-org/liquid-rust" }
+handlebars = "1"
+horrorshow = "0.6"
+liquid = "0.15"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.7"
-tera = { git = "https://github.com/Keats/tera" }
+tera = "0.11"
 
 [[bench]]
 name = "all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "template-benchmarks-rs"
 version = "0.1.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
+build = "src/build.rs"
 
 [dependencies]
 askama = "0.7"
@@ -14,6 +15,9 @@ serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.7"
 tera = "0.11"
+
+[build-dependencies]
+ructe = "0.4"
 
 [[bench]]
 name = "all"

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -2,27 +2,37 @@
 extern crate criterion;
 extern crate template_benchmarks_rs;
 
-use template_benchmarks_rs::{askama_bench, handlebars, horrorshow_bench, liquid, tera};
 use criterion::{Criterion, Fun};
+use template_benchmarks_rs::{askama_bench, handlebars, horrorshow_bench, liquid, ructe, tera};
 
 fn big_table(c: &mut Criterion) {
-    c.bench_functions("Big table", vec![
-        Fun::new("Askama", |b, i| askama_bench::big_table(b, i)),
-        Fun::new("Handlebars", |b, i| handlebars::big_table(b, i)),
-        Fun::new("Horrorshow", |b, i| horrorshow_bench::big_table(b, i)),
-        Fun::new("Liquid", |b, i| liquid::big_table(b, i)),
-        Fun::new("Tera", |b, i| tera::big_table(b, i)),
-    ], 50);
+    c.bench_functions(
+        "Big table",
+        vec![
+            Fun::new("Askama", |b, i| askama_bench::big_table(b, i)),
+            Fun::new("Handlebars", |b, i| handlebars::big_table(b, i)),
+            Fun::new("Horrorshow", |b, i| horrorshow_bench::big_table(b, i)),
+            Fun::new("Liquid", |b, i| liquid::big_table(b, i)),
+            Fun::new("Ructe", |b, i| ructe::big_table(b, i)),
+            Fun::new("Tera", |b, i| tera::big_table(b, i)),
+        ],
+        50,
+    );
 }
 
 fn teams(c: &mut Criterion) {
-    c.bench_functions("Teams", vec![
-        Fun::new("Askama", |b, i| askama_bench::teams(b, i)),
-        Fun::new("Handlebars", |b, i| handlebars::teams(b, i)),
-        Fun::new("Horrorshow", |b, i| horrorshow_bench::teams(b, i)),
-        Fun::new("Liquid", |b, i| liquid::teams(b, i)),
-        Fun::new("Tera", |b, i| tera::teams(b, i)),
-    ], 0);
+    c.bench_functions(
+        "Teams",
+        vec![
+            Fun::new("Askama", |b, i| askama_bench::teams(b, i)),
+            Fun::new("Handlebars", |b, i| handlebars::teams(b, i)),
+            Fun::new("Horrorshow", |b, i| horrorshow_bench::teams(b, i)),
+            Fun::new("Liquid", |b, i| liquid::teams(b, i)),
+            Fun::new("Ructe", |b, i| ructe::teams(b, i)),
+            Fun::new("Tera", |b, i| tera::teams(b, i)),
+        ],
+        0,
+    );
 }
 
 criterion_group!(benches, big_table, teams);

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,11 @@
+extern crate ructe;
+
+use ructe::compile_templates;
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let in_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("templates_ructe");
+    compile_templates(&in_dir, &out_dir).expect("compile templates");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,7 @@ pub mod askama_bench;
 pub mod handlebars;
 pub mod horrorshow_bench;
 pub mod liquid;
+pub mod ructe;
 pub mod tera;
+
+include!(concat!(env!("OUT_DIR"), "/templates.rs"));

--- a/src/ructe.rs
+++ b/src/ructe.rs
@@ -1,0 +1,48 @@
+use criterion;
+use templates;
+
+pub fn big_table(b: &mut criterion::Bencher, size: &usize) {
+    let mut table = Vec::with_capacity(*size);
+    for _ in 0..*size {
+        let mut inner = Vec::with_capacity(*size);
+        for i in 0..*size {
+            inner.push(i);
+        }
+        table.push(inner);
+    }
+    b.iter(|| {
+        let mut buf = Vec::new();
+        templates::big_table(&mut buf, &table).unwrap();
+    });
+}
+
+pub fn teams(b: &mut criterion::Bencher, _: &usize) {
+    let year = 2015;
+    let teams = vec![
+        Team {
+            name: "Jiangsu".into(),
+            score: 43,
+        },
+        Team {
+            name: "Beijing".into(),
+            score: 27,
+        },
+        Team {
+            name: "Guangzhou".into(),
+            score: 22,
+        },
+        Team {
+            name: "Shandong".into(),
+            score: 12,
+        },
+    ];
+    b.iter(|| {
+        let mut buf = Vec::new();
+        templates::teams(&mut buf, year, &teams).unwrap();
+    });
+}
+
+pub struct Team {
+    pub name: String,
+    pub score: u8,
+}

--- a/templates_ructe/big_table.rs.html
+++ b/templates_ructe/big_table.rs.html
@@ -1,0 +1,11 @@
+@(table: &Vec<Vec<usize>>)
+
+<table>
+@for row in table{
+    <tr>
+        @for col in row {
+            <td>@col</td>
+        }
+    </tr>
+}
+</table>

--- a/templates_ructe/teams.rs.html
+++ b/templates_ructe/teams.rs.html
@@ -1,0 +1,18 @@
+@use ructe::Team;
+@(year: u16, teams: &Vec<Team>)
+
+<html>
+<head>
+    <title>@year</title>
+</head>
+<body>
+    <h1>CSL @year</h1>
+    <ul>
+        @for (i, team) in teams.iter().enumerate(){
+        <li @if i==0 {class="champion"} else {}>
+            <b>@team.name</b>: @team.score
+        </li>
+        }
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
This adds Ructe support to the template benchmarks. It is close to Askama and Horrowshow, but is the slowest of the compiled template libraries. I did not update the readme because my machine does not have the same specs as the original benchmarking machine.