### PR TITLE
Speed up Teams/Markup.

### DIFF
--- a/src/markup_bench.rs
+++ b/src/markup_bench.rs
@@ -43,7 +43,7 @@ define! {
                 h1 { "CSL " {year} }
                 ul {
                     @for (index, team) in teams.iter().enumerate() {
-                        li.{if index == 0 { "champion" } else { "" }} {
+                        li.{if index == 0 { Some("champion") } else { None }} {
                             b { {team.name} } ": " {team.score}
                         }
                     }


### PR DESCRIPTION
This eliminates unnecessary calls to `write!` when `index > 0`.

See https://github.com/utkarshkukreti/markup.rs/commit/2699be6bfc4204da29b29a4e5dada1c961e98b0a.